### PR TITLE
fix: update CI configuration to use master branch and node version 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
+    branches: [master]
 
 jobs:
   quality:
@@ -14,7 +14,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: 'npm'
 
       - name: Install dependencies


### PR DESCRIPTION
This pull request updates the continuous integration (CI) workflow configuration to improve compatibility and keep dependencies up-to-date. The most important changes are:

CI configuration updates:

* Changed the CI workflow trigger branch from `main` to `master` in `.github/workflows/ci.yml`, ensuring that CI runs on pull requests targeting the correct branch.
* Updated the Node.js version used in the CI pipeline from `20` to `24` to leverage the latest features and security updates.