### PR TITLE
fix: simplify script tag for third-party widget integration

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -76,12 +76,7 @@ import ViewportFallback from '../components/viewport-fallback/ViewportFallback.a
         ],
       })}
     />
-    <!-- Trusted third-party widget; allowlist https://w.app in the site's CSP if this integration is required. -->
-    <script
-      src="https://w.app/widget-v1/lZVxGu.js"
-      type="text/javascript"
-      async
-      crossorigin="anonymous"></script>
+    <script src="https://w.app/widget-v1/lZVxGu.js" type="text/javascript" async></script>
   </Fragment>
   <div class="relative min-h-screen w-full">
     <Topbar />


### PR DESCRIPTION
This pull request makes a small update to the way the third-party widget script from `w.app` is included on the `index.astro` page. The `crossorigin="anonymous"` attribute and a comment about the Content Security Policy (CSP) have been removed from the script tag.

* Simplified the inclusion of the `w.app` widget script by removing the `crossorigin="anonymous"` attribute and the associated CSP allowlist comment in `src/pages/index.astro`.